### PR TITLE
Clarify the Vulkan Portability choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,8 +267,8 @@ The project will be located in `cmk_build/MacOS` folder.
 ### Configuring Vulkan Build Environment
 
 By default there is no Vulkan implementation on MacOS. Diligent Engine links against Vulkan loader
-and can use any implementation such as [MoltenVK](https://github.com/KhronosGroup/MoltenVK)
-or [Vulkan Portability](https://github.com/gfx-rs/portability). Install [VulkanSDK](https://vulkan.lunarg.com/sdk/home#mac)
+and can use a Vulkan Portability implementation such as [MoltenVK](https://github.com/KhronosGroup/MoltenVK)
+or [gfx-portability](https://github.com/gfx-rs/portability). Install [VulkanSDK](https://vulkan.lunarg.com/sdk/home#mac)
 and make sure that your system is properly configured as described [here](https://vulkan.lunarg.com/doc/sdk/latest/mac/getting_started.html).
 In particular, you may need to define the following environment variables (assuming that Vulkan SDK is installed at
 `~/LunarG/vulkansdk-macos`):


### PR DESCRIPTION
Both MoltenVK and gfx-portability are implementing Vulkan Portability as the standard for it is being developed.