### PR TITLE
Added CMake command to generate 'compile_commands.json' file for use with clangd.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 build
 out
 .vs
+.cache
+.build
+**compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ option(DILIGENT_BUILD_FX "Build DiligentFX module" ON)
 option(DILIGENT_BUILD_SAMPLES "Build DiligentSamples module" ON)
 option(DILIGENT_BUILD_DOCS "Build documentation" OFF)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 add_subdirectory(DiligentCore)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/DiligentCorePro")
     add_subdirectory(DiligentCorePro)


### PR DESCRIPTION
Works as expected and tested in Visual Studio Code with Clang 20.1.8.

Updated .gitignore file for various files/directories that should be ignored when using the compile_commands.json file for clangd, or a hidden build folder.