### PR TITLE
Create flake.nix for Nix users

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1761907660,
+        "narHash": "sha256-kJ8lIZsiPOmbkJypG+B5sReDXSD1KGu2VEPNqhRa/ew=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fb006b87f04c4d3bdf08cfdbc7fab9c13d94a15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,117 @@
+{
+  description = "A Modern Cross-Platform Low-Level 3D Graphics Library and Rendering Framework";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    self.submodules = true;
+  };
+
+  outputs =
+    { self, nixpkgs, ... }:
+    let
+      forAllSystems =
+        function:
+        nixpkgs.lib.genAttrs [
+          "x86_64-linux"
+          "aarch64-linux"
+          "x86_64-darwin"
+          "aarch64-darwin"
+        ] (system: function nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forAllSystems (pkgs: {
+        default = pkgs.clangStdenv.mkDerivation {
+          pname = "diligent";
+          version = "2.5.6";
+          src = ./.;
+
+          cmakeFlags = [
+            "-DDILIGENT_BUILD_SAMPLES=OFF"
+            "-DILIGENT_NO_FORMAT_VALIDATION=ON"
+          ];
+
+          nativeBuildInputs = [
+            pkgs.cmake
+            pkgs.autoPatchelfHook
+          ];
+
+          patches = [
+            (pkgs.writeText "libs.patch" ''
+              diff --git a/DiligentTools/RenderStateNotation/CMakeLists.txt b/DiligentTools/RenderStateNotation/CMakeLists.txt
+              index 726e376..492d2e3 100644
+              --- a/DiligentTools/RenderStateNotation/CMakeLists.txt
+              +++ b/DiligentTools/RenderStateNotation/CMakeLists.txt
+
+              @@ -26,26 +26,6 @@ file(COPY ../.clang-format DESTINATION "''${RSN_PARSER_GENERATED_HEADERS_DIR}")
+
+               find_package(Python3 REQUIRED)
+
+              -set(LIBCLANG_INSTALL_CMD ''${Python3_EXECUTABLE} -m pip install libclang==16.0.6)
+              -set(JINJA2_INSTALL_CMD ''${Python3_EXECUTABLE} -m pip install jinja2)
+              -
+              -if(''${Python3_VERSION} VERSION_GREATER_EQUAL "3.11")
+              -    set(LIBCLANG_INSTALL_CMD ''${LIBCLANG_INSTALL_CMD} --break-system-packages)
+              -    set(JINJA2_INSTALL_CMD ''${JINJA2_INSTALL_CMD} --break-system-packages)
+              -endif()
+              -
+              -execute_process(COMMAND ''${LIBCLANG_INSTALL_CMD}
+              -                RESULT_VARIABLE PYTHON_PIP_LIBCLANG_RESULT)
+              -if(NOT PYTHON_PIP_LIBCLANG_RESULT EQUAL "0")
+              -    message(FATAL_ERROR "Command ''\'''${LIBCLANG_INSTALL_CMD}' failed with error code ''${PYTHON_PIP_LIBCLANG_RESULT}")
+              -endif()
+              -
+              -execute_process(COMMAND ''${JINJA2_INSTALL_CMD}
+              -                RESULT_VARIABLE PYTHON_PIP_JINJIA_RESULT)
+              -if(NOT PYTHON_PIP_JINJIA_RESULT EQUAL "0")
+              -    message(FATAL_ERROR "Command ''\'''${JINJA2_INSTALL_CMD}' failed with error code ''${PYTHON_PIP_JINJIA_RESULT}")
+              -endif()
+              -
+               file(GLOB INCLUDE    include/*)
+               file(GLOB INTERFACE  interface/*)
+               file(GLOB SOURCE     src/*)
+            '')
+          ];
+
+          buildInputs = [
+            pkgs.python313
+            pkgs.xorg.libX11
+            pkgs.libGL
+            pkgs.xorg.libXrandr
+            pkgs.xorg.libXinerama
+            pkgs.xorg.libXcursor
+            pkgs.xorg.libXi
+            pkgs.libxcb
+            pkgs.python313Packages.libclang
+            pkgs.python313Packages.jinja2
+
+            pkgs.glslang
+            pkgs.vulkan-headers
+            pkgs.vulkan-loader
+            pkgs.vulkan-validation-layers
+          ];
+
+          meta = {
+            description = "A Modern Cross-Platform Low-Level 3D Graphics Library and Rendering Framework";
+            longDescription = "Diligent Engine is a lightweight, high-performance graphics API abstraction layer and rendering framework for cross-platform development. It leverages the power of modern graphics APIs such as Direct3D12, Vulkan, Metal, and WebGPU, while also maintaining robust support for legacy platforms through Direct3D11, OpenGL, OpenGLES, and WebGL. Providing a consistent front-end API, Diligent Engine uses HLSL as its universal shading language and also supports platform-specific shader formats (GLSL, MSL, DirectX bytecode, SPIR-V) for optimized performance. Ideal for game engines, interactive simulations, and 3D visualization applications, Diligent Engine is open-source and distributed under the permissive Apache 2.0 license.";
+            homepage = "https://diligentgraphics.com/diligent-engine/";
+            license = pkgs.lib.licenses.asl20;
+            platforms = pkgs.lib.platforms.all;
+
+            maintainers = with pkgs.lib.maintainers; [
+              TheMostDiligent
+            ];
+          };
+
+          LD_LIBRARY_PATH = "${pkgs.vulkan-loader}/lib";
+        };
+      });
+
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = [
+            self.packages.${pkgs.system}.default
+          ];
+        };
+      });
+    };
+}


### PR DESCRIPTION
This PR creates a `flake.nix` file for Nix users on Linux and MacOS.

# What does this allow?

1. This allows Nix users on *Nix to create ephemeral shells with Diligent headers and shared libraries already in the required paths. A single `nix develop "git+https://github.com/DiligentGraphics/DiligentEngine.git?submodules=1"` command from the terminal puts the caller in a shell with DiligentEngine installed.
There is a shorter command: `nix develop github:DiligentGraphics/DiligentEngine` but it doesn't work with submodules and Diligent makes heavy use of git submodules.

2. Other projects using Nix flakes for their dependency management can easily integrate Diligent into their dependencies.

3. This also allows easy dependency management for Diligent. The flake file will always build diligent with the suggested `clang` compiler as described in the README, fetching all the required libraries.

I want to note that I only tested this on a NixOS machine, and it's very likely for this flake to fail to build on MacOS. Feedback would be appreciated.

If #352 gets solved, integrating Diligent into a project will be as easy as installing it and finding it using CMake's `find_package`.